### PR TITLE
PR for Issue #165

### DIFF
--- a/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/EntityReader.java
+++ b/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/EntityReader.java
@@ -24,10 +24,10 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
 import org.hibernate.criterion.Order;
+import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.search.jsr352.internal.JobContextData;
 import org.hibernate.search.jsr352.internal.se.JobSEEnvironment;
-import org.hibernate.search.jsr352.internal.util.MassIndexerUtil;
 import org.hibernate.search.jsr352.internal.util.PartitionBound;
 import org.jboss.logging.Logger;
 
@@ -242,7 +242,8 @@ public class EntityReader extends AbstractItemReader {
 	private ScrollableResults buildScrollUsingCriteria(StatelessSession ss,
 			PartitionBound unit, Object checkpointId, JobContextData jobData) {
 
-		String idName = MassIndexerUtil.getIdName( entityType, session );
+		String idName = Projections.id().toString();
+
 		Criteria criteria = ss.createCriteria( entityType );
 
 		// build criteria using checkpoint ID

--- a/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/EntityReader.java
+++ b/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/EntityReader.java
@@ -24,7 +24,6 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.StatelessSession;
 import org.hibernate.criterion.Order;
-import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 import org.hibernate.search.jsr352.internal.JobContextData;
 import org.hibernate.search.jsr352.internal.se.JobSEEnvironment;

--- a/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/EntityReader.java
+++ b/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/EntityReader.java
@@ -242,7 +242,8 @@ public class EntityReader extends AbstractItemReader {
 	private ScrollableResults buildScrollUsingCriteria(StatelessSession ss,
 			PartitionBound unit, Object checkpointId, JobContextData jobData) {
 
-		String idName = Projections.id().toString();
+		String idName = sessionFactory.getClassMetadata( entityType )
+				.getIdentifierPropertyName();
 
 		Criteria criteria = ss.createCriteria( entityType );
 

--- a/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/PartitionMapper.java
+++ b/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/PartitionMapper.java
@@ -224,10 +224,11 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 			criterions.forEach( c -> criteria.add( c ) );
 		}
 		ScrollableResults scroll = criteria
-				.addOrder( Order.asc( Projections.id().toString() ) )
 				.setProjection( Projections.id() )
+				.setProjection( Projections.alias( Projections.id(), "aliasedId" ) )
 				.setFetchSize( Integer.parseInt( fetchSize ) )
 				.setReadOnly( true )
+				.addOrder( Order.asc( "aliasedId" ) )
 				.scroll( ScrollMode.FORWARD_ONLY );
 		return scroll;
 	}

--- a/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/PartitionMapper.java
+++ b/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/PartitionMapper.java
@@ -31,7 +31,6 @@ import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Projections;
 import org.hibernate.search.jsr352.internal.JobContextData;
 import org.hibernate.search.jsr352.internal.se.JobSEEnvironment;
-import org.hibernate.search.jsr352.internal.util.MassIndexerUtil;
 import org.hibernate.search.jsr352.internal.util.PartitionBound;
 import org.jboss.logging.Logger;
 
@@ -220,12 +219,12 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 	private ScrollableResults buildScrollableResults(StatelessSession ss,
 			Session session, Class<?> clazz, Set<Criterion> criterions) {
 
-		String fieldID = MassIndexerUtil.getIdName( clazz, session );
 		Criteria criteria = ss.createCriteria( clazz );
 		if ( criterions != null ) {
 			criterions.forEach( c -> criteria.add( c ) );
 		}
-		ScrollableResults scroll = criteria.addOrder( Order.asc( fieldID ) )
+		ScrollableResults scroll = criteria
+				.addOrder( Order.asc( Projections.id().toString() ) )
 				.setProjection( Projections.id() )
 				.setFetchSize( Integer.parseInt( fetchSize ) )
 				.setReadOnly( true )

--- a/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/PartitionMapper.java
+++ b/core/src/main/java/org/hibernate/search/jsr352/internal/steps/lucene/PartitionMapper.java
@@ -224,7 +224,6 @@ public class PartitionMapper implements javax.batch.api.partition.PartitionMappe
 			criterions.forEach( c -> criteria.add( c ) );
 		}
 		ScrollableResults scroll = criteria
-				.setProjection( Projections.id() )
 				.setProjection( Projections.alias( Projections.id(), "aliasedId" ) )
 				.setFetchSize( Integer.parseInt( fetchSize ) )
 				.setReadOnly( true )

--- a/core/src/main/java/org/hibernate/search/jsr352/internal/util/MassIndexerUtil.java
+++ b/core/src/main/java/org/hibernate/search/jsr352/internal/util/MassIndexerUtil.java
@@ -13,8 +13,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Base64;
 
-import org.hibernate.Session;
-import org.hibernate.search.hcore.util.impl.ContextHelper;
 import org.hibernate.search.jsr352.internal.JobContextData;
 import org.jboss.logging.Logger;
 
@@ -24,14 +22,6 @@ import org.jboss.logging.Logger;
 public class MassIndexerUtil {
 
 	public static final Logger LOGGER = Logger.getLogger( MassIndexerUtil.class );
-
-	public static String getIdName(Class<?> entityType, Session session) {
-		return ContextHelper.getSearchintegrator( session )
-				.getIndexBindings()
-				.get( entityType )
-				.getDocumentBuilder()
-				.getIdentifierName();
-	}
 
 	public static String serialize(JobContextData ctxData)
 			throws IOException {

--- a/core/src/test/java/org/hibernate/search/jsr352/entity/WhoAmI.java
+++ b/core/src/test/java/org/hibernate/search/jsr352/entity/WhoAmI.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.jsr352.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Indexed;
+
+/**
+ * "Who Am I" is a poorly-formed entity. It has multiple ID-like fields, which make it difficult to identify the real
+ * identifier.
+ *
+ * @author Mincong Huang
+ */
+@Entity
+@Indexed
+public class WhoAmI {
+
+	@Id
+	@DocumentId
+	private String customId;
+
+	@Field
+	private String id;
+
+	@Field
+	private String uid;
+
+	public WhoAmI() {
+	}
+
+	public WhoAmI(String customId, String id, String uid) {
+		this.customId = customId;
+		this.id = id;
+		this.uid = uid;
+	}
+
+	public String getCustomId() {
+		return customId;
+	}
+
+	public void setCustomId(String customId) {
+		this.customId = customId;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getUid() {
+		return uid;
+	}
+
+	public void setUid(String uid) {
+		this.uid = uid;
+	}
+}


### PR DESCRIPTION
- Issue #165: Use `Projections#id()` instead of `DocumentBuilderIndexedEntity#getIdPropertyName()` to avoid null reference issue for provided IDs.
- Issue #168: Test the batch job runnability over a poorly-formed entity