### PR TITLE
Clean up provided dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,8 +47,8 @@
         <dependency>
             <groupId>javax.batch</groupId>
             <artifactId>javax.batch-api</artifactId>
-            <version>${javax.batch}</version>
         </dependency>
+
         <!-- test -->
         <dependency>
             <groupId>junit</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,6 +19,7 @@
     <description>New implementation of mass-indexer using JSR 352</description>
 
     <properties>
+        <javax.batch>1.0</javax.batch>
         <org.jboss.byteman>3.0.6</org.jboss.byteman>
         <org.mockito>1.10.19</org.mockito>
     </properties>
@@ -39,19 +40,14 @@
             <version>3.3.0.Final</version>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.batch</groupId>
-            <artifactId>jboss-batch-api_1.0_spec</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <scope>provided</scope>
+            <groupId>javax.batch</groupId>
+            <artifactId>javax.batch-api</artifactId>
+            <version>${javax.batch}</version>
         </dependency>
         <!-- test -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,9 +19,7 @@
     <description>New implementation of mass-indexer using JSR 352</description>
 
     <properties>
-        <javax.batch>1.0</javax.batch>
         <org.jboss.byteman>3.0.6</org.jboss.byteman>
-        <org.mockito>1.10.19</org.mockito>
     </properties>
 
     <dependencies>
@@ -37,7 +35,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <version>3.3.0.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -57,13 +54,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>${org.mockito}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-            <version>${org.hibernate}</version>
             <scope>test</scope>
         </dependency>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,7 +42,6 @@
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.batch</groupId>

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -38,12 +38,6 @@
         <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
-            <version>2.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.batch</groupId>

--- a/integrationtest/performance/pom.xml
+++ b/integrationtest/performance/pom.xml
@@ -46,8 +46,8 @@
             <artifactId>hibernate-jpa-2.1-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.batch</groupId>
-            <artifactId>jboss-batch-api_1.0_spec</artifactId>
+            <groupId>javax.batch</groupId>
+            <artifactId>javax.batch-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -40,12 +40,6 @@
         <dependency>
             <groupId>org.jboss.ejb3</groupId>
             <artifactId>jboss-ejb3-ext-api</artifactId>
-            <version>2.1.0</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.batch</groupId>

--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -48,8 +48,8 @@
             <artifactId>hibernate-jpa-2.1-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.batch</groupId>
-            <artifactId>jboss-batch-api_1.0_spec</artifactId>
+            <groupId>javax.batch</groupId>
+            <artifactId>javax.batch-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.ejb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,19 +93,15 @@
                 <version>${org.hibernate.search}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.spec.javax.batch</groupId>
-                <artifactId>jboss-batch-api_1.0_spec</artifactId>
-                <version>1.0.0.Final</version>
+                <groupId>javax.batch</groupId>
+                <artifactId>javax.batch-api</artifactId>
+                <version>1.0</version>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>
                 <artifactId>javax.inject</artifactId>
                 <version>1</version>
-            </dependency>
-            <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>1.1</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.hibernate.javax.persistence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
                 <groupId>javax.batch</groupId>
                 <artifactId>javax.batch-api</artifactId>
                 <version>1.0</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <org.jboss.arquillian.version>1.1.1.Final</org.jboss.arquillian.version>
         <org.jberet>1.3.0.Beta2</org.jberet>
         <org.hibernate.search>5.7.0.Beta2</org.hibernate.search>
+        <org.mockito>1.10.19</org.mockito>
         <!-- TODO WFLY-7000 change to WildFly 11 when they're ready -->
         <!-- <org.wildfly>11.0.0.Alpha1-SNAPSHOT</org.wildfly> -->
         <org.wildfly>10.0.0.Final</org.wildfly>
@@ -93,6 +94,11 @@
                 <version>${org.hibernate.search}</version>
             </dependency>
             <dependency>
+	            <groupId>org.jboss.logging</groupId>
+	            <artifactId>jboss-logging</artifactId>
+	            <version>3.3.0.Final</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.batch</groupId>
                 <artifactId>javax.batch-api</artifactId>
                 <version>1.0</version>
@@ -105,14 +111,16 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.hibernate.javax.persistence</groupId>
-                <artifactId>hibernate-jpa-2.1-api</artifactId>
-                <version>1.0.0.Final</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jboss.spec.javax.ejb</groupId>
                 <artifactId>jboss-ejb-api_3.2_spec</artifactId>
                 <version>1.0.0.Final</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.ejb3</groupId>
+                <artifactId>jboss-ejb3-ext-api</artifactId>
+                <version>2.1.0</version>
+                <scope>provided</scope>
             </dependency>
 
             <!-- Test -->
@@ -132,6 +140,11 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${org.mockito}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Issue #72.

- `org.jboss.spec.javax.batch` is replaced by `javax.batch`, which I believe more standard for users.
- `javax.enterprise` was here because this was written in https://jberet.gitbooks.io/jberet-user-guide/content/set_up_jberet/ But I think this page only explains how JBeret works behind the screen. It doesn't mean that we need to depends on `javax.entreprise:cdi-api` directly. So this dependency can be deleted safely.

As for `javax.inject`, I don't know what to do... In the spec page 4,

> This specification describes the job specification language, Java programming model, ... **Additionally, it is designed to work with dependency injection (DI) containers without prescribing a particular DI implementation.**

It seems that spec does not depends on `javax.inject` directly, inside, this spec should work with both CDI and DI. Therefore, if `javax.inject` is deleted right now, the code breaks immediately. I think we can handle it in another PR.